### PR TITLE
provide overlays.default

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ inputs = {
 # home.nix
 nixpkgs = {
   overlays = [
-    inputs.brew-nix.overlay.${builtins.currentSystem}
+    inputs.brew-nix.overlays.default
   ];
 };
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,12 +9,19 @@
   };
 
   outputs =
-    { nixpkgs
+    { self
+    , nixpkgs
     , flake-utils
     , brew-api
     , ...
     }:
-    flake-utils.lib.eachDefaultSystem (
+    {
+      overlays.default = final: prev: {
+        brewCasks = self.packages;
+      };
+    }
+    //
+    (flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = import nixpkgs {
@@ -35,5 +42,5 @@
 
         packages = pkgs.callPackage ./casks.nix { inherit brew-api; };
       }
-    );
+    ));
 }


### PR DESCRIPTION
Since Nix 2.7 `overlay` is deprecated in favor to `overlays.default` https://nix.dev/manual/nix/2.22/release-notes/rl-2.7.html?highlight=overlay#release-27-2022-03-07