### PR TITLE
Provide module for nix-darwin which applies overlay and provides correct Nix version when enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ As of writing this on 2024-05-04, nixos-unstable seems to come with nix 2.18.2
 nix build github:BatteredBunny/brew-nix#blender
 ./result/Applications/Blender.app/Contents/MacOS/Blender
 ```
+## Using with nix-darwin
+
+See [`examples/flake.nix`](examples/flake.nix).
 
 ## Using with home-manager
 ```nix

--- a/examples/flake.lock
+++ b/examples/flake.lock
@@ -3,17 +3,45 @@
     "brew-api": {
       "flake": false,
       "locked": {
-        "lastModified": 1715459953,
-        "narHash": "sha256-ZIee5pYbALp/8vEdGC/4RPWR+Eja80ZA4tPxeZjq18o=",
+        "lastModified": 1722594564,
+        "narHash": "sha256-mE90Gy9+m+L92D3geFieXGQGp9gIJthasE6LS50Jr5c=",
         "owner": "BatteredBunny",
         "repo": "brew-api",
-        "rev": "f90513befc4e9acb7905e6c227e9926d126a7d67",
+        "rev": "7849cc738fbf88d7a98d9a57aa663e5cf4df30e8",
         "type": "github"
       },
       "original": {
         "owner": "BatteredBunny",
         "repo": "brew-api",
         "type": "github"
+      }
+    },
+    "brew-nix": {
+      "inputs": {
+        "brew-api": [
+          "brew-api"
+        ],
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nix-darwin": [
+          "nix-darwin"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "dirtyRev": "7c55a2f23925049c24f0f8f7cddfff89e20e976d-dirty",
+        "dirtyShortRev": "7c55a2f-dirty",
+        "lastModified": 1722601785,
+        "narHash": "sha256-HaU917XVRir5g0Werdx91ApoK66SVMsJxpkz6M1ALfc=",
+        "type": "git",
+        "url": "file:../"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:../"
       }
     },
     "flake-utils": {
@@ -56,16 +84,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715266358,
-        "narHash": "sha256-doPgfj+7FFe9rfzWo1siAV2mVCasW+Bh8I1cToAXEE4=",
+        "lastModified": 1722460556,
+        "narHash": "sha256-icgowa4FsmHJ2lH7wGwF95e7fvm7IsSVkhn6yjmHXdA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f1010e0469db743d14519a1efd37e23f8513d714",
+        "rev": "b87dfeec0dd13dd7bdea01877df48a8d7eb46091",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-24.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -73,6 +101,7 @@
     "root": {
       "inputs": {
         "brew-api": "brew-api",
+        "brew-nix": "brew-nix",
         "flake-utils": "flake-utils",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"

--- a/examples/flake.lock
+++ b/examples/flake.lock
@@ -32,16 +32,14 @@
         ]
       },
       "locked": {
-        "dirtyRev": "7c55a2f23925049c24f0f8f7cddfff89e20e976d-dirty",
-        "dirtyShortRev": "7c55a2f-dirty",
-        "lastModified": 1722601785,
-        "narHash": "sha256-HaU917XVRir5g0Werdx91ApoK66SVMsJxpkz6M1ALfc=",
-        "type": "git",
-        "url": "file:../"
+        "lastModified": 0,
+        "narHash": "sha256-gUsWbPS1Iutp1Yfw2MvQv+RMAWqZnQLudW/WKJ6tnWE=",
+        "path": "../",
+        "type": "path"
       },
       "original": {
-        "type": "git",
-        "url": "file:../"
+        "path": "../",
+        "type": "path"
       }
     },
     "flake-utils": {

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -1,3 +1,5 @@
+# The `flake.lock` for this flake probably won't work, it's for development,
+# better generate your own.
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
@@ -7,7 +9,9 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     brew-nix = {
-      url = "git+file:../";
+      # for local testing via `nix flake check` while developing 
+      #url = "path:../";
+      url = "github:BatteredBunny/brew-nix";
       inputs.nix-darwin.follows = "nix-darwin";
       inputs.brew-api.follows = "brew-api";
       inputs.flake-utils.follows = "flake-utils";

--- a/examples/flake.nix
+++ b/examples/flake.nix
@@ -1,0 +1,36 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.05-darwin";
+    flake-utils.url = "github:numtide/flake-utils";
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    brew-nix = {
+      url = "git+file:../";
+      inputs.nix-darwin.follows = "nix-darwin";
+      inputs.brew-api.follows = "brew-api";
+      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    brew-api = {
+      url = "github:BatteredBunny/brew-api";
+      flake = false;
+    };
+  };
+
+  outputs = { self, nixpkgs, nix-darwin, brew-nix, ... }: {
+    darwinConfigurations.somehost = nix-darwin.lib.darwinSystem {
+      system = "x86_64-darwin";
+      modules = [
+        brew-nix.darwinModules.default
+        ({ pkgs, ... }: {
+          brew-nix.enable = true;
+          environment.systemPackages = [
+            pkgs.brewCasks.marta
+          ];
+        })
+      ];
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -28,11 +28,7 @@
           inherit system;
         };
       in
-      rec {
-        overlay = final: prev: {
-          brewCasks = packages;
-        };
-
+      {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             nixVersions.latest # needed for builtins.convertHash

--- a/flake.nix
+++ b/flake.nix
@@ -20,11 +20,22 @@
     , nix-darwin
     , ...
     }:
+    let
+      # less than 2.19 does not do it, but let's not go overboard with latest version
+      nixRequiredVersion = rec {
+        versionSatisfiesRequirement = pkgs: nix: (builtins.compareVersions nix.version pkgs.nixVersions.nix_2_19.version) >= 0;
+        package = pkgs:
+          if versionSatisfiesRequirement pkgs pkgs.nix
+          then pkgs.nix
+          else pkgs.nixVersions.nix_2_19;
+        message = "Nix version 2.19 is required at least.";
+      };
+    in
     rec {
       overlays.default = final: prev: {
         brewCasks = self.packages.${final.system};
       };
-      darwinModules.default = (import ./module.nix) { brewCasks = overlays.default; };
+      darwinModules.default = (import ./module.nix) { brewCasks = overlays.default; inherit nixRequiredVersion; };
     }
     //
     (flake-utils.lib.eachDefaultSystem (
@@ -37,16 +48,22 @@
       {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
-            nixVersions.latest # needed for builtins.convertHash
+            (nixRequiredVersion.package pkgs)
             wget
           ];
         };
 
         packages = import ./casks.nix { inherit brew-api; inherit pkgs; lib = pkgs.lib; stdenv = pkgs.stdenv; };
 
+        # XXX: the check only runs successful on Darwin systems, but is provided for "eachDefaultSystem",
+        #      including Linux; probably best to limit systems in general, since `casks.nix` is obviously
+        #      tailored towards Darwin systems and not Linux or anything else
         checks.build-examples = let
           # override darwin-rebuild to use correct Nix version
-          darwin-rebuild-path = (nix-darwin.packages.${system}.darwin-rebuild.overrideAttrs (prev: { path = (pkgs.nixVersions.nix_2_19) + "/bin:" + prev.path; }));
+          # XXX: There seems to be some incompatibility of lock-files between Nix versions.
+          #      This error occurs when a different Nix version is used to build the system than was used
+          #      to lock the flake in `examples/`: https://github.com/NixOS/nix/issues/10815
+          darwin-rebuild-path = (nix-darwin.packages.${system}.darwin-rebuild.overrideAttrs (prev: { path = (nixRequiredVersion.package pkgs) + "/bin:" + prev.path; }));
         in
           pkgs.runCommandLocal "build-examples" {} ''
             export HOME=$(mktemp -d)

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,13 @@
+{ brewCasks }:
+{ config, lib, ... }: let
+  cfg = config.brew-nix;
+in
+with lib; {
+  options = {
+    brew-nix.enable = mkEnableOption "Activate brew-nix overlay and casks at `pkgs.brewCasks`";
+  };
+
+  config = mkIf cfg.enable {
+    nixpkgs.overlays = [ brewCasks ];
+  };
+}

--- a/module.nix
+++ b/module.nix
@@ -1,5 +1,5 @@
-{ brewCasks }:
-{ config, lib, ... }: let
+{ brewCasks, nixRequiredVersion }:
+{ config, pkgs, lib, ... }: let
   cfg = config.brew-nix;
 in
 with lib; {
@@ -9,5 +9,13 @@ with lib; {
 
   config = mkIf cfg.enable {
     nixpkgs.overlays = [ brewCasks ];
+    nix.package = mkDefault (nixRequiredVersion.package pkgs);
+
+    assertions = [
+      {
+        assertion = nixRequiredVersion.versionSatisfiesRequirement pkgs config.nix.package;
+        message = nixRequiredVersion.message;
+      }
+    ];
   };
 }


### PR DESCRIPTION
I extended your flake a bit on the configuration side. I implemented a small module for nix-darwin that applies your overlay and provides or at least assures the correct Nix version, when enabled.

The changes can be tested by performing `nix flake check`, which builds a rudimentary `examples/flakes.nix` provided. It produces a lot of warnings because of the missing hashes for the packages, but should succeed anyways.

People using your flake the previous way should be fine. As far as I can tell, this is no breaking change; at least in regard to the existing example code — but I did not actually test it.

Regarding automatic testing: The example given in its current state is for end users. If you want to run the test during development, you have to change the `inputs.brew-nix.url` in the example flake — I left a comment there. I don't like it, but I don't have any idea for a better solution to distinguish between production and development environment for now. 🤷