### PR TITLE
fix(artifacts): do not base build on artifacts

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -1,4 +1,10 @@
-{ pkgs, lib, brew-api, stdenv, ... }:
+{
+  pkgs,
+  lib,
+  brew-api,
+  stdenv,
+  ...
+}:
 let
   hasBinary = cask: lib.hasAttr "binary" (getArtifacts cask);
   hasApp = cask: lib.hasAttr "app" (getArtifacts cask);
@@ -6,93 +12,205 @@ let
 
   getName = cask: builtins.elemAt cask.name 0;
 
-  getBinary = cask: builtins.elemAt (getArtifacts cask).binary 0;
   getApp = cask: builtins.elemAt (getArtifacts cask).app 0;
+  getPkg = cask: builtins.elemAt (getArtifacts cask).pkg 0;
+  getBinary = cask: builtins.elemAt (getArtifacts cask).binary 0;
   getArtifacts = cask: lib.mergeAttrsList cask.artifacts;
 
-  caskToDerivation = cask: stdenv.mkDerivation rec {
-    pname = cask.token;
-    version = cask.version;
+  urlIsDmg = cask: lib.hasSuffix ".dmg" cask.url;
+  urlIsApp = cask: lib.hasSuffix ".app" cask.url;
+  urlIsPkg = cask: lib.hasSuffix ".pkg" cask.url;
 
-    src = pkgs.fetchurl {
-      url = cask.url;
-      hash = lib.optionalString (cask.sha256 != "no_check") (builtins.convertHash {
-        hash = cask.sha256;
-        toHashFormat = "sri";
-        hashAlgo = "sha256";
-      });
+  caskToDerivation =
+    cask:
+    stdenv.mkDerivation rec {
+      pname = cask.token;
+      version = cask.version;
+
+      src = pkgs.fetchurl {
+        # TODO: do we need to look at `cask.variations` and choose
+        # an appropriate variation?
+        url = cask.url;
+        hash = lib.optionalString (cask.sha256 != "no_check") (
+          builtins.convertHash {
+            hash = cask.sha256;
+            toHashFormat = "sri";
+            hashAlgo = "sha256";
+          }
+        );
+      };
+
+      nativeBuildInputs =
+        with pkgs;
+        [
+          xxd
+          undmg
+          unzip
+          gzip
+          _7zz
+          makeWrapper
+        ]
+        ++ lib.optional (hasPkg cask) (
+          with pkgs;
+          [
+            xar
+            cpio
+          ]
+        );
+
+      # unpack the downloaded source, maybe should not concern itself
+      # with final artifacts just yet. Just perform bare minimum to
+      # make final artifacts findable.
+      # perform steps based on cask.url.
+      unpackPhase =
+        # uncomment for debug statements
+        # ''
+        #   set -x
+        # '' +
+        (
+          if (urlIsDmg cask) then
+            ''
+              undmg $src
+              ${
+                if (hasPkg cask) then
+                  ''
+                    # do some more extraction on the pkg, it should probably exist at this point
+                    xar -xf "${getPkg cask}"
+                    for pkg in $(cat Distribution | grep -oE "#.+\.pkg" | sed -e "s/^#//" -e "s/$/\/Payload/"); do
+                      zcat $pkg | cpio -i
+                    done
+                  ''
+                else
+                  ''''
+              }
+              ${
+                if (hasApp cask) then
+                  ''
+                    echo "checking app exists..."
+
+                    if [ ! -e "${getApp cask}" ]; then
+                      echo "NO SUCH FILE: ${getApp cask}"
+                      ls -la
+                      exit 1
+                    fi
+                  ''
+                else
+                  ''''
+              }
+            ''
+          else if (urlIsPkg cask) then
+            ''
+              xar -xf $src
+              for pkg in $(cat Distribution | grep -oE "#.+\.pkg" | sed -e "s/^#//" -e "s/$/\/Payload/"); do
+                zcat $pkg | cpio -i
+              done
+            ''
+          else if (urlIsApp cask) then
+            ''
+              7zz x -snld $src
+            ''
+          # we don't know a-priori what `src` is...
+          else
+            ''
+              SRC_FILE_TYPE=$(file --mime-type -b "$src")
+
+              # https://newosxbook.com/DMG.html
+              # DMG files are proprietary format. We can detect this way.
+              if [ -n "$(xxd -s -512 -l 4 "$src" | grep "koly$")" ]; then
+                undmg $src
+              ${
+                if (hasBinary cask) then
+                  # TODO: I am not sure this is correct...
+                  # we should probably just blindly unpack into $out
+                  # and not base it upon the artifacts
+                  ''
+                    elif [ "$SRC_FILE_TYPE" == "application/gzip" ]; then
+                      gunzip $src -c > ${getBinary cask}
+                    elif [ "$SRC_FILE_TYPE" == "application/x-mach-binary" ]; then
+                      cp $src ${getBinary cask}
+                  ''
+                else
+                  ''''
+              }
+              elif [ "$SRC_FILE_TYPE" == "application/zip" ]; then
+                unzip $src
+              else
+                echo "Unhandled file type: $SRC_FILE_TYPE"
+                exit 1
+              fi
+            ''
+        );
+
+      # TODO: WHY ARE WE IN A SUBDIR NOW?
+      # I cannot figure out why the `cd` command happens ...
+      # It is helpful, but I just don't know how it works.
+
+      sourceRoot = lib.optionalString (hasApp cask) (getApp cask);
+
+      # apply final installations on all artifacts
+      installPhase = ''
+        pwd
+        ls -la
+        ${
+          if (hasPkg cask) then
+            ''
+              if [ -d "Applications" ]; then
+                mkdir -p $out/Applications
+                cp -R Applications/* "$out/Applications/"
+              fi
+
+              if [ -d "Resources" ]; then
+                mkdir -p "$out/Resources"
+                cp -R Resources/* "$out/Resources/"
+              fi
+
+              if [ -d "Library" ]; then
+                mkdir -p "$out/Library"
+                cp -R Library/* "$out/Library/"
+              fi
+            ''
+          else
+            ''''
+        }
+        ${
+          if (hasApp cask) then
+            ''
+              mkdir -p "$out/Applications/${sourceRoot}"
+              cp -R . "$out/Applications/${sourceRoot}"
+
+              if [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" ]]; then
+                makeWrapper "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" $out/bin/${cask.token}
+              elif [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${lib.removeSuffix ".app" sourceRoot}" ]]; then
+                makeWrapper "$out/Applications/${sourceRoot}/Contents/MacOS/${lib.removeSuffix ".app" sourceRoot}" $out/bin/${cask.token}
+              fi
+            ''
+          else
+            ''''
+        }
+        ${
+          if (hasBinary cask && !hasApp cask) then
+            ''
+              mkdir -p $out/bin
+              cp -R "./*" "$out/bin"
+            ''
+          else
+            ''''
+        }
+      '';
+
+      meta = {
+        homepage = cask.homepage;
+        description = cask.desc;
+        platforms = lib.platforms.darwin;
+        mainProgram = if (hasBinary cask && !hasApp cask) then (getBinary cask) else (cask.token);
+      };
     };
-
-    nativeBuildInputs = with pkgs; [
-      undmg
-      unzip
-      gzip
-      _7zz
-      makeWrapper
-    ] ++ lib.optional (hasPkg cask) (with pkgs; [
-      xar
-      cpio
-    ]);
-
-    unpackPhase =
-      if (hasPkg cask) then ''
-        xar -xf $src
-        for pkg in $(cat Distribution | grep -oE "#.+\.pkg" | sed -e "s/^#//" -e "s/$/\/Payload/"); do
-          zcat $pkg | cpio -i
-        done
-      '' else if (hasApp cask) then ''
-        undmg $src || 7zz x -snld $src
-      '' else if (hasBinary cask) then ''
-        if [ "$(file --mime-type -b "$src")" == "application/gzip" ]; then
-          gunzip $src -c > ${getBinary cask}
-        elif [ "$(file --mime-type -b "$src")" == "application/x-mach-binary" ]; then
-          cp $src ${getBinary cask}
-        fi
-      '' else "";
-
-    sourceRoot = lib.optionalString (hasApp cask) (getApp cask);
-
-    installPhase =
-      if (hasPkg cask) then ''
-        mkdir -p $out/Applications
-        cp -R Applications/* $out/Applications/
-
-        if [ -d "Resources" ]; then
-          mkdir -p $out/Resources
-          cp -R Resources/* $out/Resources/
-        fi
-
-        if [ -d "Library" ]; then
-          mkdir -p $out/Library
-          cp -R Library/* $out/Library/
-        fi
-      '' else if (hasApp cask) then ''
-        mkdir -p "$out/Applications/${sourceRoot}"
-        cp -R . "$out/Applications/${sourceRoot}"
-
-        if [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" ]]; then
-          makeWrapper "$out/Applications/${sourceRoot}/Contents/MacOS/${getName cask}" $out/bin/${cask.token}
-        elif [[ -e "$out/Applications/${sourceRoot}/Contents/MacOS/${lib.removeSuffix ".app" sourceRoot}" ]]; then
-          makeWrapper "$out/Applications/${sourceRoot}/Contents/MacOS/${lib.removeSuffix ".app" sourceRoot}" $out/bin/${cask.token}
-        fi
-      '' else if (hasBinary cask && !hasApp cask) then ''
-        mkdir -p $out/bin
-        cp -R ./* $out/bin
-      '' else "";
-
-    meta = {
-      homepage = cask.homepage;
-      description = cask.desc;
-      platforms = lib.platforms.darwin;
-      mainProgram = if (hasBinary cask && !hasApp cask) then (getBinary cask) else (cask.token);
-    };
-  };
 
   casks = builtins.fromJSON (builtins.readFile (brew-api + "/cask.json"));
 in
-builtins.listToAttrs (builtins.map
-  (cask: {
+builtins.listToAttrs (
+  builtins.map (cask: {
     name = cask.token;
     value = caskToDerivation cask;
-  })
-  casks)
+  }) casks
+)


### PR DESCRIPTION
Hello, thank you for providing this cool repository and alternative to homebrew. I think it is really cool. 

I am not sure if this PR should just be accepeted even though it does fix https://github.com/BatteredBunny/brew-nix/issues/1 . The code is ugly and bad, but I was able to get these casks working: 
```nix
[
  # already working, but still work
  brewCasks.bitwarden
  (brewCasks.chromium.overrideAttrs (oldAttrs: {
    src = pkgs.fetchurl {
      url = builtins.head oldAttrs.src.urls;
      hash = "sha256-zZHAB7TozshPfoVRfAllYFl4kXrXAok2KqHPa3gSu/c=";
    };
  }))
  brewCasks.firefox
  brewCasks.protonvpn
  brewCasks.raycast
  brewCasks.slack
  # were not working, but now work
  brewCasks.sage # 👀 
  brewCasks.sf-symbols # 😃 
]
```

I was facing similar issue installing `sf-symbols` because I wanted them for my sketchybar setup.

I think I made a lot of mistakes, but it is hard for me to tell without testing and some more things to run against, and my issue is already fixed, so I just want to turn in what I have now for review before I try and fix something that already works in a bad way.

`nix flake check` fails, but that also fails on `main`.