### PR TITLE
Pass sha256 to fetchurl directly instead of converting to sri

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 Experimental nix expression to package all MacOS casks from [homebrew](https://brew.sh/) automatically.
 
-## Dependencies
-Requires at least nixos 24.11 or nixos-unstable to work due to relying on ``builtins.convertHash`` from nix 2.19
-
 ## Benefits over nix-darwin's homebrew module
 1. No homebrew needed, packages are fully managed by nix.
 2. Fully nix package expressions, everything is type checked and it will give you an error when you specify an invalid package for example.

--- a/casks.nix
+++ b/casks.nix
@@ -16,11 +16,7 @@ let
 
     src = pkgs.fetchurl {
       url = cask.url;
-      hash = lib.optionalString (cask.sha256 != "no_check") (builtins.convertHash {
-        hash = cask.sha256;
-        toHashFormat = "sri";
-        hashAlgo = "sha256";
-      });
+      sha256 = lib.optionalString (cask.sha256 != "no_check") cask.sha256;
     };
 
     nativeBuildInputs = with pkgs; [


### PR DESCRIPTION
This allows for compatibility with nix 2.18 (and lix)