### PR TITLE
Don't patch shebangs

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -52,6 +52,9 @@ let
 
     sourceRoot = lib.optionalString (hasApp cask) (getApp cask);
 
+    # Patching shebangs invalidates code signing
+    dontPatchShebangs = true;
+
     installPhase =
       if (hasPkg cask) then ''
         mkdir -p $out/Applications


### PR DESCRIPTION
Nix derivations naturally find any scripts and nixify the shebang.

When Nix does this to code-signed apps it invalidates the signature.
Since it's not really desirable for the shebang to be patched anyway I've raised this PR to disable this behaviour.