### PR TITLE
Fix readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ nix build github:BatteredBunny/brew-nix#blender
 Many casks come with no hash so you have to provide one yourself
 ```nix
 home.packages = with pkgs; [
-  (brewCasks.marta.overrideAttrs (o: {
+  (brewCasks.marta.overrideAttrs (oldAttrs: {
     src = pkgs.fetchurl {
       url = builtins.head oldAttrs.src.urls;
       hash = lib.fakeHash; # Replace me with real hash after building once


### PR DESCRIPTION
While trying to override a package with no hash I noticed that the example provided in the readme had `o` defined for the old attributes, but the next line was expecting `oldAttrs`. I just switched both to `oldAttrs`, might help someone out in the future.