### PR TITLE
Update flake.nix for NixOS 25.11

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -46,7 +46,7 @@
       );
 
       overlays.default = final: _: {
-        brewCasks = self.packages.${final.system};
+        brewCasks = self.packages.${final.stdenv.hostPlatform.system};
       };
 
       darwinModules.default = lib.modules.importApply ./module.nix { brewCasks = self.overlays.default; };


### PR DESCRIPTION
evaluation warning of NixOS 23.11: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'