### PR TITLE
Explain reason for `brew-api` flake input

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ See [`examples/flake.nix`](examples/flake.nix).
 
 ## Setup with home-manager
 
+**Note**: It’s important to set up the `brew-api` input because that’s where the Homebrew formulae are stored. It gets updated much more frequently than `brew-nix`, so if you only have the `brew-nix` input, you’ll have out-of-date versions of programs installed and potential Nix eval failures if those old versions are no longer available from their source.
+
 ```nix
 # flake.nix
 inputs = {

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ home.packages = lib.attrsets.attrValues {
 
 `brew-nix` is structured into 2 repos for modularity:
 - The main repo `brew-nix` containg the nix expression to parse cask data to nix packages.
-- Automated `brew-api` repo containing the brew casks summary information.
+- Automated [`brew-api`](https://github.com/BatteredBunny/brew-api) repo containing the brew casks summary information.
 
 This has the benefit of being able to keep the git history of `brew-nix` clean, and giving the user the freedom to easily override the data used to generate the nix expressions and or update `brew-api` seperatly from `brew-nix` if needed.
 

--- a/README.md
+++ b/README.md
@@ -75,13 +75,22 @@ home.packages = lib.attrsets.attrValues {
 
 # Setup
 
+`brew-nix` is structured into 2 repos for modularity:
+- The main repo `brew-nix` containg the nix expression to parse cask data to nix packages.
+- Automated `brew-api` repo containing the brew casks summary information.
+
+This has the benefit of being able to keep the git history of `brew-nix` clean, and giving the user the freedom to easily override the data used to generate the nix expressions and or update `brew-api` seperatly from `brew-nix` if needed.
+
+> [!WARNING]
+> `brew-api` input part is not optional. You should define your own `brew-api` input like below.
+>
+> If you omit it, `brew-nix` will use a stale version of `brew-api` which is updated infrequently and may not work.
+
 ## Setup with nix-darwin
 
 See [`examples/flake.nix`](examples/flake.nix).
 
 ## Setup with home-manager
-
-**Note**: It’s important to set up the `brew-api` input because that’s where the Homebrew formulae are stored. It gets updated much more frequently than `brew-nix`, so if you only have the `brew-nix` input, you’ll have out-of-date versions of programs installed and potential Nix eval failures if those old versions are no longer available from their source.
 
 ```nix
 # flake.nix


### PR DESCRIPTION
I had inadvertently left out `brew-api` when I set up `brew-nix`. I only noticed because on a recent `home-manager switch` with a new cask added, evaluation failed because the version in brew-nix’s pinned `brew-api` input was no longer available.

This hopefully makes it clear why a user should set up `brew-api`, even though they do nothing with it besides override another flake’s input.

Another suggestion is that `brew-api` might be more clearly named `brew-formulae` or something that makes it clear it’s the data source for `brew-nix` and not something more static, like an API definition.