### PR TITLE
fix: flatten conditional nativeBuildInputs

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -75,7 +75,7 @@
           _7zz
           makeWrapper
         ]
-        ++ lib.lists.optional usePkgPath (
+        ++ lib.lists.optionals usePkgPath (
           with pkgs; [
             xar
             cpio


### PR DESCRIPTION
Use `lib.optionals` for conditional `nativeBuildInputs` entries to avoid creating nested lists.

Nixpkgs 26.05 deprecates nested lists in `nativeBuildInputs`, and future releases will remove support for them.

When evaluating `desktoppr` with Nixpkgs 26.05, this warning is already shown:

```
evaluation warning: Dependency of package 'desktoppr' uses a nested list in attribute 'nativeBuildInputs'.
                    This is deprecated as of Nixpkgs release 26.05, and support will
                    be removed in a future nixpkgs release.
```