### PR TITLE
fix: handle pbzx-compressed Payloads in pkg-based casks

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -80,6 +80,7 @@
             xar
             cpio
             fd
+            pbzx
           ]
         );
 
@@ -88,7 +89,11 @@
         then ''
           xar -xf $src
           for pkg in $(cat Distribution | grep -oE "#.+\.pkg" | sed -e "s/^#//" -e "s/$/\/Payload/"); do
-            zcat $pkg | cpio -i
+            if head -c 4 "$pkg" | grep -q "pbzx"; then
+              pbzx -n "$pkg" | cpio -i
+            else
+              zcat "$pkg" | cpio -i
+            fi
           done
         ''
         else if isApp
@@ -162,6 +167,16 @@
           if [ -d "Library" ]; then
             mkdir -p $out/Library
             cp -R Library/* $out/Library/
+          fi
+
+          if [ -d "Contents" ] && [ -f "Contents/Info.plist" ]; then
+            bundleName=$(sed -n '/<key>CFBundleName<\/key>/{n;s/.*<string>\(.*\)<\/string>.*/\1/p;}' Contents/Info.plist 2>/dev/null || echo "App")
+            mkdir -p "$out/Applications/$bundleName.app"
+            cp -R Contents "$out/Applications/$bundleName.app/"
+            exe=$(sed -n '/<key>CFBundleExecutable<\/key>/{n;s/.*<string>\(.*\)<\/string>.*/\1/p;}' Contents/Info.plist 2>/dev/null)
+            if [ -n "$exe" ] && [ -f "$out/Applications/$bundleName.app/Contents/MacOS/$exe" ]; then
+              makeWrapper "$out/Applications/$bundleName.app/Contents/MacOS/$exe" "$out/bin/${cask.token}"
+            fi
           fi
         ''
         else if isApp


### PR DESCRIPTION
<!-- PR authored with assistance from AI (pi coding agent) -->

## Description

Fixes a build failure for pkg-based casks whose internal `Payload` file uses Apple's **pbzx** compression (LZMA/XZ chunks) instead of gzip. The Tailscale app cask (`tailscale-app`) is a prominent example.

### Problem

The current `unpackPhase` for pkg-based casks assumes all Payload files are gzip-compressed:

```bash
zcat $pkg | cpio -i
```

When the Payload is pbzx-compressed, this fails with:

```
$ nix build 'github:BatteredBunny/brew-nix#tailscale-app' --no-link

error: Cannot build '/nix/store/...-tailscale-app-1.96.5.drv'.
       Reason: builder failed with exit code 2.
       Output paths:
         /nix/store/...-tailscale-app-1.96.5
       Last 4 log lines:
       > Running phase: unpackPhase
       >
       > gzip: Distribution.pkg/Payload: not in gzip format
       > cpio: premature end of archive
       For full logs, run:
         nix log /nix/store/...-tailscale-app-1.96.5.drv
```

Additionally, some pkgs (like Tailscale's) extract a flat `Contents/` directory rather than a `.app` bundle, `Applications/`, or `Library/` — none of which are handled by the current `installPhase`.

### Changes

1. **`nativeBuildInputs`** — added `pbzx` for pkg-based casks.

2. **`unpackPhase`** — detect pbzx magic bytes (`head -c 4 | grep -q "pbzx"`) and use `pbzx -n` for decompression, with `zcat` as fallback for traditional gzip Payloads.

3. **`installPhase`** — added a fallback for flat packages: when a `Contents/` directory with `Info.plist` is found, wrap it into a `.app` bundle (reading `CFBundleName` from the plist) and create a `bin/` wrapper via `makeWrapper`.

### Testing

Built `tailscale-app` (v1.96.5) successfully:

```
$ nix build 'git+file:///.../brew-nix#tailscale-app' --no-link
  → /nix/store/gb144dr7n0r1wwdqah94z1xv64abkanh-tailscale-app-1.96.5

--- Build log ---
Running phase: unpackPhase
136354 blocks
Running phase: patchPhase
Running phase: configurePhase
no configure script, doing nothing
Running phase: buildPhase
no Makefile or custom buildPhase, doing nothing
Running phase: installPhase
Running phase: fixupPhase

--- Output tree ---
Applications/
  Tailscale.app/
    Contents/
      _CodeSignature/
      Frameworks/
      Library/
      MacOS/
        Tailscale
      PlugIns/
        ShareExtension-macsys.appex/
      Resources/
        ...
bin/
  tailscale-app -> ../Applications/Tailscale.app/Contents/MacOS/Tailscale
```

The fix is backward-compatible: gzip Payloads continue to use `zcat` as before, and pkgs that already extract to `Applications/` or `.app` bundles are unaffected.

---

*This PR was created with assistance from an AI coding agent.*