### PR TITLE
fix: use unzip for zip-format casks to handle 7zip 26+ link checks

### DIFF
--- a/casks.nix
+++ b/casks.nix
@@ -98,17 +98,25 @@
         else if isApp
         then ''
           case "$src" in
-            *.zip)            unzip "$src" ;;
+            *.zip)            unzip -q "$src" ;;
             *.tar.gz|*.tgz)   tar -xzf "$src" ;;
             *.tar.xz)         tar -xJf "$src" ;;
             *.tar.bz2|*.tbz2) tar -xjf "$src" ;;
             *)
-              # Try undmg first, then 7zz if it doesn't work
-              # 7zz has weird issues with decompressing many times but supports more formats
+              # Try undmg first, then dispatch by detected mime type
+              # 7zz 26+ rejects "dangerous link via another link" patterns that are
+              # legitimate in macOS .app bundles (e.g. Versions/Current chains in
+              # nested frameworks). Prefer unzip for zip-format archives since it
+              # tolerates these links; fall back to 7zz for other archive formats.
               cp -- "$src" ./archive
               if ! undmg ./archive 2>/dev/null; then
-                7zz x -snld ./archive
-                find . -name '*:com.apple.*' -print -delete
+                mime="$(file --mime-type -b ./archive)"
+                if [ "$mime" = "application/zip" ]; then
+                  unzip -q ./archive
+                else
+                  7zz x -snld ./archive
+                  find . -name '*:com.apple.*' -print -delete
+                fi
               fi
               rm -f ./archive
               if [ ! -e "${getApp artifacts}" ]; then
@@ -123,7 +131,7 @@
         else if isBinary
         then ''
           case "$src" in
-            *.zip)            unzip "$src" ;;
+            *.zip)            unzip -q "$src" ;;
             *.tar.gz|*.tgz)   tar -xzf "$src" ;;
             *.tar.xz)         tar -xJf "$src" ;;
             *.tar.bz2|*.tbz2) tar -xjf "$src" ;;
@@ -134,6 +142,8 @@
                 gunzip $src -c > ${getBinary artifacts}
               elif [ "$mime" == "application/x-mach-binary" ]; then
                 cp $src ${getBinary artifacts}
+              elif [ "$mime" == "application/zip" ]; then
+                unzip -q "$src"
               else
                 7zz x -snld "$src"
               fi

--- a/casks.nix
+++ b/casks.nix
@@ -103,21 +103,29 @@
             *.tar.xz)         tar -xJf "$src" ;;
             *.tar.bz2|*.tbz2) tar -xjf "$src" ;;
             *)
-              # Try undmg first, then dispatch by detected mime type
+              # Dispatch by content because some cask URLs have no archive extension.
               # 7zz 26+ rejects "dangerous link via another link" patterns that are
               # legitimate in macOS .app bundles (e.g. Versions/Current chains in
-              # nested frameworks). Prefer unzip for zip-format archives since it
-              # tolerates these links; fall back to 7zz for other archive formats.
+              # nested frameworks). Prefer unzip for zip-format archives.
               cp -- "$src" ./archive
-              if ! undmg ./archive 2>/dev/null; then
-                mime="$(file --mime-type -b ./archive)"
-                if [ "$mime" = "application/zip" ]; then
+              mime="$(file --mime-type -b ./archive)"
+              case "$mime" in
+                application/zip)
                   unzip -q ./archive
-                else
-                  7zz x -snld ./archive
+                  ;;
+                application/x-apple-diskimage)
+                  # undmg only supports HFS images
+                  if ! undmg ./archive 2>/dev/null; then
+                    7zz x -snld20 ./archive
+                    find . -name '*:com.apple.*' -print -delete
+                  fi
+                  ;;
+                *)
+                  # Used for APFS images
+                  7zz x -snld20 ./archive
                   find . -name '*:com.apple.*' -print -delete
-                fi
-              fi
+                  ;;
+              esac
               rm -f ./archive
               if [ ! -e "${getApp artifacts}" ]; then
                 nested=$(find . -mindepth 2 -maxdepth 3 -name "${getApp artifacts}" -print -quit)

--- a/test.py
+++ b/test.py
@@ -23,6 +23,7 @@ CASKS: list[tuple[Kind, str]] = [
     ("app", "kitty"),  # APFS dmg
     ("app", "sabaki"),  # 7z
     ("app", "raycast"),  # dmg fetched from URL with no archive extension
+    ("app", "whatsapp"),  # extensionless zip with nested framework links
     ("pkg", "alfaview"),  # flat pkg
     ("pkg", "aquaskk"),  # flat pkg
     ("pkg", "sage"),  # dmg with both .app and .pkg


### PR DESCRIPTION
7zip 26.00 adds stricter rejection of "dangerous link via another link" patterns — it errors out and exits non-zero even with `-snld`. The catch is that macOS `.app` bundles legitimately rely on this: framework `Versions/Current` symlinks resolve through each other, so things like VS Code, WhatsApp, and other nested-framework apps fail when extraction falls through to 7zz.

This detects the archive's mime type and routes `application/zip` through `unzip` instead (which doesn't mind these symlink chains). 7zz stays as the fallback for other formats / DMGs / etc. Also extends the `isBinary` mime dispatch to handle `application/zip` for consistency.

Tested locally with VS Code and WhatsApp — both build cleanly now.